### PR TITLE
Update the Google authorization instructions

### DIFF
--- a/macintosh-02.md
+++ b/macintosh-02.md
@@ -214,12 +214,18 @@ name@computer current-folder %
 This environment variable will be used when you are accessing this project through [GitHub Codespaces](https://github.com/features/codespaces).
 We will be following the process shown [here](https://docs.github.com/en/codespaces/managing-your-codespaces/managing-encrypted-secrets-for-your-codespaces#adding-a-secret).
 
-**NOTE:** It is absolutely imperative that you DO NOT save the contents of `service_account_key.json` in your repository or check it in at all. If someone else were able to see the contents of that file, they could execute any action that service account has in its abilities.
+**NOTE:** It is absolutely imperative that you DO NOT commit the contents of `service_account_key.json` to your repository at all. If someone else were able to see the contents of that file, they could execute any action that service account has in its abilities.
+Since `service_account_key.json` is in the `.gitignore` file, you should not be able to check it in, but it is important to remember that for the sake of transparency.
 
 Step-specific information:
-4. The "Name" of the secret will be `GOOGLE_APPLICATION_CREDENTIALS`.
+4. The "Name" of the secret will be `GOOGLE_CREDENTIALS`.
 5. The "Value" of the secret will be the contents of the `$HOME/.config/gcloud/service_account_key.json` file.
-6. The repository that you will give access to it will be the name of the repository you are using in the Codespace.
+6. The repository that you will give access to it will be the name of the repository you are using in the Codespace, presumably `icj-project-rig`.
+
+When you open your Codespace, you will run the following command, and you should be able to get to work quickly:
+```bash
+$ printenv GOOGLE_CREDENTIALS > service_account_key.json && export GOOGLE_APPLICATION_CREDENTIALS=service_account_key.json
+```
 
 ## Test these settings
 1. Create a folder in your icj folder called `yourname-test`.

--- a/macintosh-02.md
+++ b/macintosh-02.md
@@ -224,7 +224,7 @@ Step-specific information:
 
 When you open your Codespace, you will run the following command, and you should be able to get to work quickly:
 ```bash
-$ printenv GOOGLE_CREDENTIALS > service_account_key.json && export GOOGLE_APPLICATION_CREDENTIALS=service_account_key.json
+$ npm run codespace-google-auth
 ```
 
 ## Test these settings

--- a/macintosh-02.md
+++ b/macintosh-02.md
@@ -100,6 +100,7 @@ Homebrew/homebrew-core (git revision 6fb14ad0d84; last commit 2023-03-20)
 Homebrew/homebrew-cask (git revision d15dfcc577; last commit 2023-03-20)
 name@computer current-folder % 
 ```
+
 2. Click on [this link](https://formulae.brew.sh/cask/google-cloud-sdk) to download the `gcloud` CLI tool. 
 Just like the above command this may take a second, but wait until it says it is finished.
 Once the installation has finished, run the command `gcloud --version` in your terminal, and you should get some output similar to this:
@@ -122,6 +123,7 @@ This will open a browser where it will show you all of your available Google nam
 After you select your _personal_ gmail account, you will be sent to a permissions screen that will look something like this:
 <img src='images/gcloud_cli_permissions.png' height='500'> \
 Click `Allow` and you will have given your computer access to manage files on your Google Drive and in the Google Cloud Project.
+
 4. Now we are going to [create the project](https://cloud.google.com/sdk/gcloud/reference/projects/create) that we are going to work with in this class via the command `gcloud projects create icj-project --set-as-default --name="ICJ Project"`.
 This command creates our new project called something similar to `icj-project-[Random Numbers]` on the Google Cloud Platform and sets it as our default project.
 
@@ -196,7 +198,7 @@ created key [VERY_LARGE_STRING] of type [json] as [$HOME/.config/gcloud/service_
 name@computer current-folder %
 ```
 
-Add the key to your `~/.bash_profile` through the command line.
+Add the key to your `.bash_profile` through the command line.
 ```bash
 name@computer current-folder % echo 'export GOOGLE_APPLICATION_CREDENTIALS="$HOME/.config/gcloud/service_account_key.json"' >>~/.bash_profile
 name@computer current-folder %

--- a/macintosh-02.md
+++ b/macintosh-02.md
@@ -132,7 +132,7 @@ No project id provided.
 Use [icj-project-390720] as project id (Y/n)?  y
 
 Create in progress for [https://cloudresourcemanager.googleapis.com/v1/projects/icj-project-390720].
-Waiting for [operations/cp.7750740892332052334] to finish...done.                                                                                                                            
+Waiting for [operations/VERY_LARGE_STRING] to finish...done.                                                                                                                            
 Enabling service [cloudapis.googleapis.com] on project [icj-project-390720]...
 Operation "operations/acat.p2-379330608294-a07db4fa-06c4-4da3-babc-7c44f5dd168d" finished successfully.
 Updated property [core/project] to [icj-project-390720].
@@ -184,7 +184,7 @@ name@computer current-folder %
 Enables the Google Docs and Sheets API for your project.
 ```bash
 name@computer current-folder % gcloud services enable docs.googleapis.com sheets.googleapis.com
-Operation "operations/acat.p2-486343904898-f2a645cc-8c3d-4998-bdb5-3bcb2e3cae26" finished successfully.
+Operation "operations/[VERY_LARGE_STRING]" finished successfully.
 name@computer current-folder %
 ```
 
@@ -192,7 +192,7 @@ Create the service account authorization keys.
 ```bash
 name@computer current-folder % gcloud iam service-accounts keys create "$HOME/.config/gcloud/service_account_key.json" \
     --iam-account=generic-service-account@[YOUR PROJECT ID].iam.gserviceaccount.com
-created key [101b317f623e04d2f76e22d4da030ad3aa1633a0] of type [json] as [$HOME/.config/gcloud/service_account_key.json] for [generic-service-account@[YOUR PROJECT ID].iam.gserviceaccount.com]
+created key [VERY_LARGE_STRING] of type [json] as [$HOME/.config/gcloud/service_account_key.json] for [generic-service-account@[YOUR PROJECT ID].iam.gserviceaccount.com]
 name@computer current-folder %
 ```
 

--- a/macintosh-02.md
+++ b/macintosh-02.md
@@ -46,17 +46,19 @@ Use NVM to install Node.
 1. Install `v16.18.0` of Node via the next two commands:
 
 ```bash
-name@computer icj-project-rig % nvm install 16.18.0
+name@computer current-folder % nvm install 16.18.0
 ...
-name@computer icj-project-rig % nvm use 16.18.0    
+name@computer current-folder % nvm use 16.18.0    
 Now using node v16.18.0 (npm v8.19.2)
+name@computer current-folder %
 ```
 
 2. **Test**: Do `node -v` to make sure it worked. It should give you back "v16.18.0".
 
 ```bash
-name@computer icj-project-rig % node -v 
+name@computer current-folder % node -v 
 v16.18.0
+name@computer current-folder %
 ```
 
 ### npm
@@ -92,17 +94,17 @@ Click on the brew link, copy the text beginning with `/bin/bash`, and then paste
 This may take a minute and put out a lot of information on your terminal, but just wait until it is done.
 Once the installation has finished, run the command `brew --version` in your console, and you should get output similar to this:
 ```bash
-name@computer icj-project-rig % brew --version
+name@computer current-folder % brew --version
 Homebrew 4.0.22
 Homebrew/homebrew-core (git revision 6fb14ad0d84; last commit 2023-03-20)
 Homebrew/homebrew-cask (git revision d15dfcc577; last commit 2023-03-20)
-name@computer icj-project-rig % 
+name@computer current-folder % 
 ```
 2. Click on [this link](https://formulae.brew.sh/cask/google-cloud-sdk) to download the `gcloud` CLI tool. 
 Just like the above command this may take a second, but wait until it says it is finished.
 Once the installation has finished, run the command `gcloud --version` in your terminal, and you should get some output similar to this:
 ```bash
-name@computer icj-project-rig % gcloud --version
+name@computer current-folder % gcloud --version
 Google Cloud SDK 428.0.0
 bq 2.0.91
 core 2023.04.25
@@ -111,7 +113,7 @@ gsutil 5.23
 Updates are available for some Google Cloud CLI components.  To install them,
 please run:
   $ gcloud components update
-name@computer icj-project-rig % 
+name@computer current-folder % 
 ```
 
 3. We are now going to authenticate our Google credentials on our local machine, using the following command `gcloud auth login --brief --enable-gdrive-access`. 
@@ -120,12 +122,27 @@ This will open a browser where it will show you all of your available Google nam
 After you select your _personal_ gmail account, you will be sent to a permissions screen that will look something like this:
 <img src='images/gcloud_cli_permissions.png' height='500'> \
 Click `Allow` and you will have given your computer access to manage files on your Google Drive and in the Google Cloud Project.
-4. Now we are going to [create the project](https://cloud.google.com/sdk/gcloud/reference/projects/create) that we are going to work with in this class via the command `gcloud projects create icj-project --set-as-default`.
-This command creates our new project called `icj-project` on the Google Cloud Platform and sets it as our default project.
+4. Now we are going to [create the project](https://cloud.google.com/sdk/gcloud/reference/projects/create) that we are going to work with in this class via the command `gcloud projects create icj-project --set-as-default --name="ICJ Project"`.
+This command creates our new project called something similar to `icj-project-[Random Numbers]` on the Google Cloud Platform and sets it as our default project.
 
-Once this process is done, enter the command `gcloud auth application-default login` into your terminal, follow the browser prompts, and you should be able to see what project you are logged into.
 ```bash
-name@computer icj-project-rig % gcloud auth application-default login
+name@computer current-folder % gcloud projects create --set-as-default --name="ICJ Project"
+No project id provided.
+
+Use [icj-project-390720] as project id (Y/n)?  y
+
+Create in progress for [https://cloudresourcemanager.googleapis.com/v1/projects/icj-project-390720].
+Waiting for [operations/cp.7750740892332052334] to finish...done.                                                                                                                            
+Enabling service [cloudapis.googleapis.com] on project [icj-project-390720]...
+Operation "operations/acat.p2-379330608294-a07db4fa-06c4-4da3-babc-7c44f5dd168d" finished successfully.
+Updated property [core/project] to [icj-project-390720].
+name@computer current-folder %
+```
+
+
+5. Enter the command `gcloud auth application-default login` into your terminal, follow the browser prompts, and you should be able to see what project you are logged into.
+```bash
+name@computer current-folder % gcloud auth application-default login
 Your browser has been opened to visit:
 
     https://accounts.google.com/o/oauth2/auth?[VERY_LARGE_STRING]
@@ -136,22 +153,71 @@ Credentials saved to file: [$HOME/.config/gcloud/application_default_credentials
 These credentials will be used by any library that requests Application Default Credentials (ADC).
 
 Quota project "[RECENTLY_CREATED_PROJECT_ID]" was added to ADC which can be used by Google client libraries for billing and quota. Note that some services may still bill the project owning the resource.
-name@computer icj-project-rig % 
+name@computer current-folder % 
 ```
 
-### Setting up the environment variable
-This environment variable will be used when you are accessing this project through [GitHub Codespaces](https://github.com/features/codespaces).
-To create the environment variable, make sure that you logged in using the `gcloud` command above.
+6. Take the project ID, `icj-project-390720` in this example, and enter the following commands, and you should see similar outputs.
 
-1. In a Terminal, enter `code ~/.bash_profile` to open your ".bash_profile" file in VS Code. In there, you should see some stuff there already from other configurations. (Holler if you don't as that means you are likely in the wrong file.)
-2. Add the text below to the `~./bash_profile` file, save, and exit the file.
+Creates a service account called `generic-service-account`.
 ```bash
-# Google Auth
-export GOOGLE_APPLICATION_CREDENTIALS="$HOME/.config/gcloud/application_default_credentials.json"
+name@computer current-folder % gcloud iam service-accounts create generic-service-account
+Created service account [generic-service-account].
+name@computer current-folder %
 ```
+
+Binds the `generic-service-account` to the editor role for the specified project.
+```bash
+name@computercurrent-folder % gcloud projects add-iam-policy-binding [YOUR PROJECT ID] --member='serviceAccount:generic-service-account@[YOUR PROJECT ID].iam.gserviceaccount.com' --role='roles/editor'
+Updated IAM policy for project [[YOUR PROJECT ID]].
+bindings:
+- members:
+  - serviceAccount:generic-service-account@[YOUR PROJECT ID].iam.gserviceaccount.com
+  role: roles/editor
+- members:
+  - user:emailAddress@gmail.com
+  role: roles/owner
+etag: BwX-xm7Obo4=
+version: 1
+name@computer current-folder %
+```
+
+Enables the Google Docs and Sheets API for your project.
+```bash
+name@computer current-folder % gcloud services enable docs.googleapis.com sheets.googleapis.com
+Operation "operations/acat.p2-486343904898-f2a645cc-8c3d-4998-bdb5-3bcb2e3cae26" finished successfully.
+name@computer current-folder %
+```
+
+Create the service account authorization keys.
+```bash
+name@computer current-folder % gcloud iam service-accounts keys create "$HOME/.config/gcloud/service_account_key.json" \
+    --iam-account=generic-service-account@[YOUR PROJECT ID].iam.gserviceaccount.com
+created key [101b317f623e04d2f76e22d4da030ad3aa1633a0] of type [json] as [$HOME/.config/gcloud/service_account_key.json] for [generic-service-account@[YOUR PROJECT ID].iam.gserviceaccount.com]
+name@computer current-folder %
+```
+
+Add the key to your `~/.bash_profile` through the command line.
+```bash
+name@computer current-folder % echo 'export GOOGLE_APPLICATION_CREDENTIALS="$HOME/.config/gcloud/service_account_key.json"' >>~/.bash_profile
+name@computer current-folder %
+```
+
+Sync your terminal with the current state of your `.bash_profile`.
+```bash
+name@computer current-folder % source ~/.bash_profile
+name@computer current-folder %
+```
+
+### Setting up the environment variable for GitHub Codespaces
+This environment variable will be used when you are accessing this project through [GitHub Codespaces](https://github.com/features/codespaces).
+We will be following the process shown [here](https://docs.github.com/en/codespaces/managing-your-codespaces/managing-encrypted-secrets-for-your-codespaces#adding-a-secret).
+
+Step-specific information:
+4. The "Name" of the secret will be `GOOGLE_APPLICATION_CREDENTIALS`.
+5. The "Value" of the secret will be the contents of the `$HOME/.config/gcloud/service_account_key.json` file.
+6. The repository that you will give access to it will be the name of the repository you are using in the Codespace.
 
 ## Test these settings
-
 1. Create a folder in your icj folder called `yourname-test`.
 2. Open that folder in Visual Studio Code.
 3. Open a VS Code Terminal and run:

--- a/macintosh-02.md
+++ b/macintosh-02.md
@@ -212,6 +212,8 @@ name@computer current-folder %
 This environment variable will be used when you are accessing this project through [GitHub Codespaces](https://github.com/features/codespaces).
 We will be following the process shown [here](https://docs.github.com/en/codespaces/managing-your-codespaces/managing-encrypted-secrets-for-your-codespaces#adding-a-secret).
 
+**NOTE:** It is absolutely imperative that you DO NOT save the contents of `service_account_key.json` in your repository or check it in at all. If someone else were able to see the contents of that file, they could execute any action that service account has in its abilities.
+
 Step-specific information:
 4. The "Name" of the secret will be `GOOGLE_APPLICATION_CREDENTIALS`.
 5. The "Value" of the secret will be the contents of the `$HOME/.config/gcloud/service_account_key.json` file.

--- a/windows-02.md
+++ b/windows-02.md
@@ -136,13 +136,18 @@ We'll test this with the icj-project-template when the time comes. If you use On
 This environment variable will be used when you are accessing this project through [GitHub Codespaces](https://github.com/features/codespaces).
 We will be following the process shown [here](https://docs.github.com/en/codespaces/managing-your-codespaces/managing-encrypted-secrets-for-your-codespaces#adding-a-secret).
 
-**NOTE:** It is absolutely imperative that you DO NOT save the contents of `service_account_key.json` in your repository or check it in at all. 
-If someone else were able to see the contents of that file, they could execute any action that service account has in its abilities.
+**NOTE:** It is absolutely imperative that you DO NOT commit the contents of `service_account_key.json` to your repository at all. If someone else were able to see the contents of that file, they could execute any action that service account has in its abilities.
+Since `service_account_key.json` is in the `.gitignore` file, you should not be able to check it in, but it is important to remember that for the sake of transparency.
 
 Step-specific information:
-4. The "Name" of the secret will be `GOOGLE_APPLICATION_CREDENTIALS`.
+4. The "Name" of the secret will be `GOOGLE_CREDENTIALS`.
 5. The "Value" of the secret will be the contents of the `$APPDATA\gcloud\service_account_key.json` file.
-6. The repository that you will give access to it will be the name of the repository you are using in the Codespace.
+6. The repository that you will give access to it will be the name of the repository you are using in the Codespace, presumably `icj-project-rig`.
+
+When you open your Codespace, you will run the following command, and you should be able to get to work quickly:
+```bash
+$ printenv GOOGLE_CREDENTIALS > service_account_key.json && export GOOGLE_APPLICATION_CREDENTIALS=service_account_key.json
+```
 
 ## Possible test scenario
 - Create a folder in your icj folder called `yourname-test`.

--- a/windows-02.md
+++ b/windows-02.md
@@ -45,13 +45,24 @@ please run:
 2. We are now going to authenticate our Google credentials on our local machine, using the following command `gcloud auth login --brief --enable-gdrive-access`.
    This will open a browser where it will show you all of your available Google names.
    **Make sure to select your _personal_ gmail account for this part**. If you use your `utexas.edu` email, you won't have permission to do what we need to do.
-   After you select your _personal_ gmail account, you will be sent to a permissions screen that will look something like this:
+   After you select your _personal_ gmail account, you will be sent to a permissions screen that will look something like this: \
    <img src='images/gcloud_cli_permissions.png' height='500'> \
    Click `Allow` and you will have given your computer access to manage files on your Google Drive and in the Google Cloud Project.
-3. Now we are going to [create the project](https://cloud.google.com/sdk/gcloud/reference/projects/create) that we are going to work with in this class via the command `gcloud projects create icj-project --set-as-default`.
-   This command creates our new project called `icj-project` on the Google Cloud Platform and sets it as our default project.
+```bash
+% gcloud projects create --set-as-default --name="ICJ Project"
+No project id provided.
 
-Once this process is done, enter the command `gcloud auth application-default login` into your terminal, follow the browser prompts, and you should be able to see what project you are logged into.
+Use [icj-project-390720] as project id (Y/n)?  y
+
+Create in progress for [https://cloudresourcemanager.googleapis.com/v1/projects/icj-project-390720].
+Waiting for [operations/VERY_LARGE_STRING] to finish...done.                                                                                                                            
+Enabling service [cloudapis.googleapis.com] on project [icj-project-390720]...
+Operation "operations/acat.p2-379330608294-a07db4fa-06c4-4da3-babc-7c44f5dd168d" finished successfully.
+Updated property [core/project] to [icj-project-390720].
+%
+```
+
+3. Enter the command `gcloud auth application-default login` into your terminal, follow the browser prompts, and you should be able to see what project you are logged into.
 ```bash
 % gcloud auth application-default login
 Your browser has been opened to visit:
@@ -67,19 +78,71 @@ Quota project "[RECENTLY_CREATED_PROJECT_ID]" was added to ADC which can be used
 % 
 ```
 
+4. Take the project ID, `icj-project-390720` in this example, and enter the following commands, and you should see similar outputs.
+
+Creates a service account called `generic-service-account`.
+```bash
+% gcloud iam service-accounts create generic-service-account
+Created service account [generic-service-account].
+%
+```
+
+Binds the `generic-service-account` to the editor role for the specified project.
+```bash
+name@computercurrent-folder % gcloud projects add-iam-policy-binding [YOUR PROJECT ID] --member='serviceAccount:generic-service-account@[YOUR PROJECT ID].iam.gserviceaccount.com' --role='roles/editor'
+Updated IAM policy for project [[YOUR PROJECT ID]].
+bindings:
+- members:
+  - serviceAccount:generic-service-account@[YOUR PROJECT ID].iam.gserviceaccount.com
+  role: roles/editor
+- members:
+  - user:emailAddress@gmail.com
+  role: roles/owner
+etag: BwX-xm7Obo4=
+version: 1
+%
+```
+
+Enables the Google Docs and Sheets API for your project.
+```bash
+% gcloud services enable docs.googleapis.com sheets.googleapis.com
+Operation "operations/[VERY_LARGE_STRING]" finished successfully.
+%
+```
+
+Create the service account authorization keys.
+```bash
+% gcloud iam service-accounts keys create "%APPDATA%\gcloud\service_account_key.json" \
+    --iam-account=generic-service-account@[YOUR PROJECT ID].iam.gserviceaccount.com
+created key [VERY_LARGE_STRING] of type [json] as [$HOME/.config/gcloud/service_account_key.json] for [generic-service-account@[YOUR PROJECT ID].iam.gserviceaccount.com]
+%
+```
+
+Add the key to your `.bash_profile` through the command line.
+```bash
+% echo 'export GOOGLE_APPLICATION_CREDENTIALS="$APPDATA\gcloud\service_account_key.json"' >>~\.bash_profile
+%
+```
+
+Sync your terminal with the current state of your `.bash_profile`.
+```bash
+% source ~\.bash_profile
+%
+```
+
 We'll test this with the icj-project-template when the time comes. If you use OneDrive, you might have to use **Git Bash** for some steps instead of the terminal within VS Code.
 
-### Setting up the environment variable
-> There _may_ be some issues setting this up on Windows machines that use OneDrive. It has been successfully installed on a non-OneDrive setup using this method.
+### Setting up the environment variable for GitHub Codespaces
+This environment variable will be used when you are accessing this project through [GitHub Codespaces](https://github.com/features/codespaces).
+We will be following the process shown [here](https://docs.github.com/en/codespaces/managing-your-codespaces/managing-encrypted-secrets-for-your-codespaces#adding-a-secret).
 
-We are setting this environment variable to authenticate ourselves to Google using the information in the json file you just created.
+**NOTE:** It is absolutely imperative that you DO NOT save the contents of `service_account_key.json` in your repository or check it in at all. 
+If someone else were able to see the contents of that file, they could execute any action that service account has in its abilities.
 
-1. Open a new Git Bash prompt.
-2. Enter `code .bash_profile` to open your `.bash_profile` file in VS Code. You should see some stuff there already from other configurations. (Holler if you don't as that means you are likely in the wrong file.)
-```bash
-# Google Auth
-set GOOGLE_APPLICATION_CREDENTIALS="$APPDATA\gcloud\application_default_credentials.json"
-```
+Step-specific information:
+4. The "Name" of the secret will be `GOOGLE_APPLICATION_CREDENTIALS`.
+5. The "Value" of the secret will be the contents of the `$APPDATA\gcloud\service_account_key.json` file.
+6. The repository that you will give access to it will be the name of the repository you are using in the Codespace.
 
 ## Possible test scenario
 - Create a folder in your icj folder called `yourname-test`.

--- a/windows-02.md
+++ b/windows-02.md
@@ -146,7 +146,7 @@ Step-specific information:
 
 When you open your Codespace, you will run the following command, and you should be able to get to work quickly:
 ```bash
-$ printenv GOOGLE_CREDENTIALS > service_account_key.json && export GOOGLE_APPLICATION_CREDENTIALS=service_account_key.json
+$ npm run codespace-google-auth
 ```
 
 ## Possible test scenario


### PR DESCRIPTION
## What documentation does this update and for what reason?
This PR updates the documentation for MacOS and Windows with regard to:
- Creating a service-account through the `gcloud` CLI
- Adding the service account secret as an encrypted environment variable in the GitHub platform so that you can access the features through the GitHub Codespaces interface