### PR TITLE
Add extra environment variable setup documentation

### DIFF
--- a/macintosh-02.md
+++ b/macintosh-02.md
@@ -211,15 +211,20 @@ name@computer current-folder %
 ```
 
 ### Setting up the environment variable for GitHub Codespaces
-This environment variable will be used when you are accessing this project through [GitHub Codespaces](https://github.com/features/codespaces).
+These environment variables will be used when you are accessing this project through [GitHub Codespaces](https://github.com/features/codespaces).
 We will be following the process shown [here](https://docs.github.com/en/codespaces/managing-your-codespaces/managing-encrypted-secrets-for-your-codespaces#adding-a-secret).
 
-**NOTE:** It is absolutely imperative that you DO NOT commit the contents of `service_account_key.json` to your repository at all. If someone else were able to see the contents of that file, they could execute any action that service account has in its abilities.
+**NOTE:** It is absolutely imperative that you DO NOT commit the contents of `service_account_key.json` to your branch at all. If someone else were able to see the contents of that file, they could execute any action that service account has in its abilities.
 Since `service_account_key.json` is in the `.gitignore` file, you should not be able to check it in, but it is important to remember that for the sake of transparency.
 
-Step-specific information:
+Step-specific information for the first environment variable:
 4. The "Name" of the secret will be `GOOGLE_CREDENTIALS`.
 5. The "Value" of the secret will be the contents of the `$HOME/.config/gcloud/service_account_key.json` file.
+6. The repository that you will give access to it will be the name of the repository you are using in the Codespace, presumably `icj-project-rig`.
+
+Step-specific information for the first environment variable:
+4. The "Name" of the secret will be `GOOGLE_APPLICATION_CREDENTIALS`.
+5. The "Value" of the secret will be `service_account_key.json`.
 6. The repository that you will give access to it will be the name of the repository you are using in the Codespace, presumably `icj-project-rig`.
 
 When you open your Codespace, you will run the following command, and you should be able to get to work quickly:

--- a/windows-02.md
+++ b/windows-02.md
@@ -133,15 +133,20 @@ Sync your terminal with the current state of your `.bash_profile`.
 We'll test this with the icj-project-template when the time comes. If you use OneDrive, you might have to use **Git Bash** for some steps instead of the terminal within VS Code.
 
 ### Setting up the environment variable for GitHub Codespaces
-This environment variable will be used when you are accessing this project through [GitHub Codespaces](https://github.com/features/codespaces).
+These environment variables will be used when you are accessing this project through [GitHub Codespaces](https://github.com/features/codespaces).
 We will be following the process shown [here](https://docs.github.com/en/codespaces/managing-your-codespaces/managing-encrypted-secrets-for-your-codespaces#adding-a-secret).
 
-**NOTE:** It is absolutely imperative that you DO NOT commit the contents of `service_account_key.json` to your repository at all. If someone else were able to see the contents of that file, they could execute any action that service account has in its abilities.
+**NOTE:** It is absolutely imperative that you DO NOT commit the contents of `service_account_key.json` to your branch at all. If someone else were able to see the contents of that file, they could execute any action that service account has in its abilities.
 Since `service_account_key.json` is in the `.gitignore` file, you should not be able to check it in, but it is important to remember that for the sake of transparency.
 
-Step-specific information:
+Step-specific information for the first environment variable:
 4. The "Name" of the secret will be `GOOGLE_CREDENTIALS`.
-5. The "Value" of the secret will be the contents of the `$APPDATA\gcloud\service_account_key.json` file.
+5. The "Value" of the secret will be the contents of the `$HOME/.config/gcloud/service_account_key.json` file.
+6. The repository that you will give access to it will be the name of the repository you are using in the Codespace, presumably `icj-project-rig`.
+
+Step-specific information for the first environment variable:
+4. The "Name" of the secret will be `GOOGLE_APPLICATION_CREDENTIALS`.
+5. The "Value" of the secret will be `service_account_key.json`.
 6. The repository that you will give access to it will be the name of the repository you are using in the Codespace, presumably `icj-project-rig`.
 
 When you open your Codespace, you will run the following command, and you should be able to get to work quickly:


### PR DESCRIPTION
## What documentation does this update and for what reason?
Unfortunately, it seems you cannot add environment variables within GitHub Codespaces outside of their UI/CLI. To address that, I modified the setup for the application.

<details><summary>Test Output</summary>

```bash
@michplunkett ➜ /workspaces/icj-project-rig (main) $ nvm install 16.18.0
v16.18.0 is already installed.
Now using node v16.18.0 (npm v8.19.2)
bash: [: -ne: unary operator expected
bash: [: -ne: unary operator expected
bash: [: -ne: unary operator expected
@michplunkett ➜ /workspaces/icj-project-rig (main) $ nvm use 16.18.0
Now using node v16.18.0 (npm v8.19.2)
@michplunkett ➜ /workspaces/icj-project-rig (main) $ npm run codespace-google-auth

> icj-project-template@1.1.0 codespace-google-auth
> printenv GOOGLE_CREDENTIALS > service_account_key.json

@michplunkett ➜ /workspaces/icj-project-rig (main) $ npm install gulp -g
npm WARN deprecated source-map-url@0.4.1: See https://github.com/lydell/source-map-url#deprecated
npm WARN deprecated urix@0.1.0: Please see https://github.com/lydell/urix#deprecated
npm WARN deprecated resolve-url@0.2.1: https://github.com/lydell/resolve-url#deprecated
npm WARN deprecated source-map-resolve@0.5.3: See https://github.com/lydell/source-map-resolve#deprecated
npm WARN deprecated chokidar@2.1.8: Chokidar 2 does not receive security updates since 2019. Upgrade to chokidar 3 with 15x fewer dependencies

added 351 packages, and audited 352 packages in 7s

13 packages are looking for funding
  run `npm fund` for details

11 vulnerabilities (6 moderate, 5 high)

To address all issues (including breaking changes), run:
  npm audit fix --force

Run `npm audit` for details.
@michplunkett ➜ /workspaces/icj-project-rig (main) $ npm ci
npm WARN deprecated source-map-url@0.4.1: See https://github.com/lydell/source-map-url#deprecated
npm WARN deprecated stable@0.1.8: Modern JS already guarantees Array#sort() is a stable sort, so this library is deprecated. See the compatibility table on MDN: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/sort#browser_compatibility
npm WARN deprecated urix@0.1.0: Please see https://github.com/lydell/urix#deprecated
npm WARN deprecated source-map-resolve@0.6.0: See https://github.com/lydell/source-map-resolve#deprecated
npm WARN deprecated resolve-url@0.2.1: https://github.com/lydell/resolve-url#deprecated
npm WARN deprecated source-map-resolve@0.5.3: See https://github.com/lydell/source-map-resolve#deprecated
npm WARN deprecated chokidar@2.1.8: Chokidar 2 does not receive security updates since 2019. Upgrade to chokidar 3 with 15x fewer dependencies
npm WARN deprecated uuid@3.4.0: Please upgrade  to version 7 or higher.  Older versions may use Math.random() in certain circumstances, which is known to be problematic.  See https://v8.dev/blog/math-random for details.
npm WARN deprecated uuid@3.4.0: Please upgrade  to version 7 or higher.  Older versions may use Math.random() in certain circumstances, which is known to be problematic.  See https://v8.dev/blog/math-random for details.
npm WARN deprecated uuid@3.4.0: Please upgrade  to version 7 or higher.  Older versions may use Math.random() in certain circumstances, which is known to be problematic.  See https://v8.dev/blog/math-random for details.

added 1367 packages, and audited 1368 packages in 23s

127 packages are looking for funding
  run `npm fund` for details

78 vulnerabilities (3 low, 56 moderate, 19 high)

To address issues that do not require attention, run:
  npm audit fix

To address all issues possible (including breaking changes), run:
  npm audit fix --force

Some issues need review, and may require choosing
a different dependency.

Run `npm audit` for details.
@michplunkett ➜ /workspaces/icj-project-rig (main) $ npm run codespace-google-auth

> icj-project-template@1.1.0 codespace-google-auth
> printenv GOOGLE_CREDENTIALS > service_account_key.json

@michplunkett ➜ /workspaces/icj-project-rig (main) $ gulp fetch
`import sass from 'sass'` is deprecated.
Please use `import * as sass from 'sass'` instead.
[21:18:23] Using gulpfile /workspaces/icj-project-rig/gulpfile.js
[21:18:23] Starting 'fetch'...
[21:18:23] Finished 'fetch' after 3.25 ms
Downloaded `library` (1RgMhjtkXlbbf9uzSzy_xPRKwxcVZIZqVytgM_JoU4E4)
Downloaded `bookstores` (1gDwO-32cgpBDn_0niV0iu6TqQTaRDr4nmSqnT53magY)
@michplunkett ➜ /workspaces/icj-project-rig (main) $ gulp
`import sass from 'sass'` is deprecated.
Please use `import * as sass from 'sass'` instead.
[21:18:33] Using gulpfile /workspaces/icj-project-rig/gulpfile.js
[21:18:33] Starting 'default'...
[21:18:33] Starting 'clean'...
[21:18:33] Finished 'clean' after 10 ms
[21:18:33] Starting 'styles'...
[21:18:47] Finished 'styles' after 13 s
[21:18:47] Starting 'copy'...
[21:18:47] Finished 'copy' after 17 ms
[21:18:47] Starting 'lint'...
[21:18:47] Starting 'scripts'...
[21:18:47] Starting 'images'...
[21:18:50] Finished 'lint' after 3.11 s
[21:18:50] Finished 'scripts' after 3.7 s
[21:18:51] gulp-imagemin: Minified 3 images (saved 198 kB - 65.2%)
[21:18:51] Finished 'images' after 3.97 s
[21:18:51] Starting 'nunjucks'...
[21:18:51] Finished 'nunjucks' after 8.28 ms
[21:18:51] Starting 'bake'...
[21:18:51] Finished 'bake' after 9.95 ms
[21:18:51] Finished 'default' after 17 s
@michplunkett ➜ /workspaces/icj-project-rig (main) $ gulp format
`import sass from 'sass'` is deprecated.
Please use `import * as sass from 'sass'` instead.
[21:18:56] Using gulpfile /workspaces/icj-project-rig/gulpfile.js
[21:18:56] Starting 'format'...
[21:18:57] Finished 'format' after 364 ms
@michplunkett ➜ /workspaces/icj-project-rig (main) $ 
```
</details>