### PR TITLE
Correct formatting issue in Github Codespaces documentation

### DIFF
--- a/macintosh-02.md
+++ b/macintosh-02.md
@@ -217,14 +217,14 @@ We will be following the process shown [here](https://docs.github.com/en/codespa
 **NOTE:** It is absolutely imperative that you DO NOT commit the contents of `service_account_key.json` to your branch at all. If someone else were able to see the contents of that file, they could execute any action that service account has in its abilities.
 Since `service_account_key.json` is in the `.gitignore` file, you should not be able to check it in, but it is important to remember that for the sake of transparency.
 
-Step-specific information for the first environment variable:
-4. The "Name" of the secret will be `GOOGLE_CREDENTIALS`.
-5. The "Value" of the secret will be the contents of the `$HOME/.config/gcloud/service_account_key.json` file.
+Step-specific information for the first environment variable:<br>
+4. The "Name" of the secret will be `GOOGLE_CREDENTIALS`.<br>
+5. The "Value" of the secret will be the contents of the `$HOME/.config/gcloud/service_account_key.json` file.<br>
 6. The repository that you will give access to it will be the name of the repository you are using in the Codespace, presumably `icj-project-rig`.
 
-Step-specific information for the first environment variable:
-4. The "Name" of the secret will be `GOOGLE_APPLICATION_CREDENTIALS`.
-5. The "Value" of the secret will be `service_account_key.json`.
+Step-specific information for the first environment variable:<br>
+4. The "Name" of the secret will be `GOOGLE_APPLICATION_CREDENTIALS`.<br>
+5. The "Value" of the secret will be `service_account_key.json`.<br>
 6. The repository that you will give access to it will be the name of the repository you are using in the Codespace, presumably `icj-project-rig`.
 
 When you open your Codespace, you will run the following command, and you should be able to get to work quickly:

--- a/windows-02.md
+++ b/windows-02.md
@@ -139,14 +139,14 @@ We will be following the process shown [here](https://docs.github.com/en/codespa
 **NOTE:** It is absolutely imperative that you DO NOT commit the contents of `service_account_key.json` to your branch at all. If someone else were able to see the contents of that file, they could execute any action that service account has in its abilities.
 Since `service_account_key.json` is in the `.gitignore` file, you should not be able to check it in, but it is important to remember that for the sake of transparency.
 
-Step-specific information for the first environment variable:
-4. The "Name" of the secret will be `GOOGLE_CREDENTIALS`.
-5. The "Value" of the secret will be the contents of the `$HOME/.config/gcloud/service_account_key.json` file.
+Step-specific information for the first environment variable:<br>
+4. The "Name" of the secret will be `GOOGLE_CREDENTIALS`.<br>
+5. The "Value" of the secret will be the contents of the `$HOME/.config/gcloud/service_account_key.json` file.<br>
 6. The repository that you will give access to it will be the name of the repository you are using in the Codespace, presumably `icj-project-rig`.
 
-Step-specific information for the first environment variable:
-4. The "Name" of the secret will be `GOOGLE_APPLICATION_CREDENTIALS`.
-5. The "Value" of the secret will be `service_account_key.json`.
+Step-specific information for the first environment variable:<br>
+4. The "Name" of the secret will be `GOOGLE_APPLICATION_CREDENTIALS`.<br>
+5. The "Value" of the secret will be `service_account_key.json`.<br>
 6. The repository that you will give access to it will be the name of the repository you are using in the Codespace, presumably `icj-project-rig`.
 
 When you open your Codespace, you will run the following command, and you should be able to get to work quickly:


### PR DESCRIPTION
## What documentation does this update and for what reason?
I verified stuff last night and saw that the part of the documentation that was dealing with GitHub Codespaces wasn't correctly formatted, so I corrected that. This should be the final addition, though it's purely aesthetic.

Before change:
<img width="1025" alt="Screenshot 2023-06-25 at 12 26 56 PM" src="https://github.com/utdata/icj-setting-up/assets/5885605/3924f564-777c-40b0-9e19-6a187d1c5a32">

After change:
<img width="981" alt="Screenshot 2023-06-25 at 12 30 34 PM" src="https://github.com/utdata/icj-setting-up/assets/5885605/4a6d0813-aa6e-4529-82ff-a05a89869044">